### PR TITLE
sparge letter

### DIFF
--- a/src/ui.h
+++ b/src/ui.h
@@ -325,7 +325,7 @@ const byte _PumpSymbol[8]  PROGMEM  = {B00000, B01110, B01010, B01110, B01000, B
 const byte _RevPumpSymbol[8] PROGMEM = {B11111, B10001, B10101, B10001, B10111, B10111, B10111, B11111};  // [4] Reverse PUMP Symbol
 const byte _HeatingSymbol[8] PROGMEM   = {	B00000, B01010, B01010, B01110, B01110, B01010, B01010, B00000};  // [5] HEAT symbol
 const byte _RevHeatingSymbol[8] PROGMEM = {B11111, B10101, B10101, B10001, B10001, B10101, B10101, B11111};  // [6] reverse HEAT symbol
-const byte _RevSpargeHeatingSymbol[8] PROGMEM={B11111,B10001,B1011,B10001,B11110,B1110,B10001,B11111};
+const byte _RevSpargeHeatingSymbol[8] PROGMEM={B11111, B11111, B10001, B01111, B10001, B11110, B00001, B11111};
 
 const byte _WirelessSymbol[8] PROGMEM =  {B00000,B01110,B10001,B00100,B01010,B00000,B00100,B00000};
 const byte _WirelessAPSymbol[8] PROGMEM ={B00000,B10001,B01010,B10101,B00100,B00100,B00100,B01110};
@@ -733,7 +733,7 @@ void uiHeatingStatus(byte status)
 #endif
 
 #if SpargeHeaterSupport == true
-char const S_STR[] PROGMEM ="S";
+char const S_STR[] PROGMEM ="s";
 
 void uiAuxHeatingStatus(byte status)
 {


### PR DESCRIPTION
When the heating of SPARGE is activated, the LCD shows the truncated image in place of the letter S, the code for reverse was incomplete. Solution: small letter.  The small letter s has a better view than the capital letter S.