### PR TITLE
Fix issue #91

### DIFF
--- a/src/BrewLogger.h
+++ b/src/BrewLogger.h
@@ -47,7 +47,11 @@ public:
 	bool checkRecovery(void){ return FileSystem.exists(BREWING_TMPFILE);}
 	void clearRecovery(void){ if(checkRecovery()) FileSystem.remove(BREWING_TMPFILE);}
 
+	#if SpargeHeaterSupport == true	
+	void resumeSession(uint8_t *pStage,uint32_t *pTime,bool *resume_sparge)
+	#else
 	void resumeSession(uint8_t *pStage,uint32_t *pTime)
+	#endif
 	{
 		_tmpFile=FileSystem.open(BREWING_TMPFILE,"a+");
 		size_t fsize= _tmpFile.size();
@@ -77,6 +81,10 @@ public:
 		// return value
 		*pStage = _stage;
 		*pTime= _time;
+
+		#if SpargeHeaterSupport == true	
+		*resume_sparge =_resume_sparge;
+		#endif
 	}
 
 	void startSession(uint8_t sensors, unsigned long period,bool fahrenheit, bool saved=true){
@@ -376,6 +384,10 @@ private:
 	size_t _pauseSum;
 	bool   _timeRunning;
 
+	#if SpargeHeaterSupport == true
+		bool   _resume_sparge = false;
+	#endif
+
 	void initProcessingResume(void)
 	{
 		_tempCount=0;
@@ -451,7 +463,11 @@ private:
 				}else if (b2 == 10){ //RemoteEventBoilFinished
     				_timeRunning=false;
 	    			_pauseSum=0;
+				#if SpargeHeaterSupport == true
+				}else if (b2 == 98){ // RemoteEventSpargeWaterAdded
+					_resume_sparge = true;	// Sparge was active, we should resume it
 				}
+				#endif
 			}else if(!(b1 & 0x80)){
 				// temperature reading
 				_tempCount ++;

--- a/src/BrewManiac.cpp
+++ b/src/BrewManiac.cpp
@@ -232,6 +232,10 @@ bool distillingEventHandler(byte);
 #define RemoteEventPumpRest         11
 #define RemoteEventPumpRestEnd      12
 
+#if SpargeHeaterSupport == true
+	#define RemoteEventSpargeWaterAdded	98	// Added to keep track of active sparge for recovery purposes
+#endif
+
 #define RemoteEventBrewFinished 	99
 
 void btReportCurrentStage(byte stage);
@@ -5456,7 +5460,14 @@ void autoModeResumeProcess(void)
 	// get stage
 	byte stage;
 	uint32_t elapsed;
+
+	#if SpargeHeaterSupport == true	
+	bool resume_sparge = false;
+	brewLogger.resumeSession(&stage,&elapsed,&resume_sparge);
+	#else
 	brewLogger.resumeSession(&stage,&elapsed);
+	#endif
+
 	DBG_PRINTF("resume state:%d, elapsed:%d\n",stage, elapsed);
 
 	setEventMask(TemperatureEventMask | ButtonPressedEventMask | TimeoutEventMask | PumpRestEventMask);
@@ -5569,6 +5580,13 @@ void autoModeResumeProcess(void)
 #if SecondaryHeaterSupport
 		setHeatingElementForStage(HeatingStageMashing);
 #endif
+#if SpargeHeaterSupport == true	 
+	if((gEnableSpargeWaterHeatingControl) && (resume_sparge))
+	{
+		// Sparge heating was active, we should resume it
+		startHeatingSpargeWater();	
+	}
+#endif
 		heatOn();
 		_state = AS_Mashing;
 		_askingSkipMashingStage = false;
@@ -5656,6 +5674,7 @@ bool autoModeAskSpargeWaterAddedHandler(byte event)
 {
 	if(btnIsStartPressed)
 	{
+		// No sparge
 		gEnableSpargeWaterHeatingControl = false;
 		#if UsePaddleInsteadOfPump
 		autoModeStartWithoutPumpPrimming();
@@ -5666,8 +5685,9 @@ bool autoModeAskSpargeWaterAddedHandler(byte event)
 	}
 	else if(btnIsEnterPressed)
 	{
-		// no sparge
+		// sparge
 		gEnableSpargeWaterHeatingControl = true;
+		brewLogger.event(RemoteEventSpargeWaterAdded); // Log sparge enabled as event for recovery purposes
 		#if UsePaddleInsteadOfPump
 		autoModeStartWithoutPumpPrimming();
 		#else


### PR DESCRIPTION
Resuming / recovery does not reactivate the sparge heating
-Add a log event to keep track of active sparge heating
-On recovery, interrogate the log and restart sparge heating if active previously