### PR TITLE
Fixed oversight: log starts at dough in  

### DIFF
--- a/src/BrewManiac.cpp
+++ b/src/BrewManiac.cpp
@@ -4435,12 +4435,12 @@ void autoModeEnterDoughIn(void)
 	#if MaximumNumberOfSensors > 1
 		brewLogger.startSession(gSensorNumber,TemperatureChartPeriod,gIsUseFahrenheit);
 		#if SpargeHeaterSupport == true
-		if (sparge_stated_flag) brewLogger.event(RemoteEventSpargeWaterAdded); // Log sparge enabled as event for recovery purposes
+		if (sparge_started_flag) brewLogger.event(RemoteEventSpargeWaterAdded); // Log sparge enabled as event for recovery purposes
 		#endif
 	#else
 		brewLogger.startSession(1,TemperatureChartPeriod,gIsUseFahrenheit);
 		#if SpargeHeaterSupport == true
-		if (sparge_stated_flag) brewLogger.event(RemoteEventSpargeWaterAdded); // Log sparge enabled as event for recovery purposes
+		if (sparge_started_flag) brewLogger.event(RemoteEventSpargeWaterAdded); // Log sparge enabled as event for recovery purposes
 		#endif		
 	#endif
 

--- a/src/BrewManiac.cpp
+++ b/src/BrewManiac.cpp
@@ -234,6 +234,7 @@ bool distillingEventHandler(byte);
 
 #if SpargeHeaterSupport == true
 	#define RemoteEventSpargeWaterAdded	98	// Added to keep track of active sparge for recovery purposes
+	bool sparge_started_flag = false;		
 #endif
 
 #define RemoteEventBrewFinished 	99
@@ -4433,8 +4434,14 @@ void autoModeEnterDoughIn(void)
 
 	#if MaximumNumberOfSensors > 1
 		brewLogger.startSession(gSensorNumber,TemperatureChartPeriod,gIsUseFahrenheit);
+		#if SpargeHeaterSupport == true
+		if (sparge_stated_flag) brewLogger.event(RemoteEventSpargeWaterAdded); // Log sparge enabled as event for recovery purposes
+		#endif
 	#else
 		brewLogger.startSession(1,TemperatureChartPeriod,gIsUseFahrenheit);
+		#if SpargeHeaterSupport == true
+		if (sparge_stated_flag) brewLogger.event(RemoteEventSpargeWaterAdded); // Log sparge enabled as event for recovery purposes
+		#endif		
 	#endif
 
 	brewLogger.stage(StageDoughIn);
@@ -5687,7 +5694,7 @@ bool autoModeAskSpargeWaterAddedHandler(byte event)
 	{
 		// sparge
 		gEnableSpargeWaterHeatingControl = true;
-		brewLogger.event(RemoteEventSpargeWaterAdded); // Log sparge enabled as event for recovery purposes
+		sparge_started_flag = true;
 		#if UsePaddleInsteadOfPump
 		autoModeStartWithoutPumpPrimming();
 		#else


### PR DESCRIPTION
Hi @vitotai 

Sorry, I had a slight oversight.
I did not notice that the brewlog only gets created at the dough in stage. As a result, my sollution to issue#91 did not work as the sparge water added event was never written (the log was not started yet). Here is a fix to this problem

Sorry for not testing properly before I submitted the pull request...
I have however thoroughly tested this fix, and it works.

Regards,
lekrom