### PR TITLE
Fix for ESP8266 bug Settings are not saved #127

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -183,7 +183,7 @@ lib_extra_dirs = ./lib-esp8266
 platform = ${common_env_data.esp8266_framework}
 board = nodemcuv2
 framework = arduino
-build_flags = -Wl,-Tesp8266.flash.4m.ld  -DMultipleSensorEnabled=true  
+build_flags = -Wl,-Tesp8266.flash.4m2m.ld -DMultipleSensorEnabled=true
 
 monitor_speed = 115200
 lib_deps = ${common_env_data.lib_deps_external} 


### PR DESCRIPTION
Proposal fix for bug #127 (ESP8266 only) where filesystem size is 0 and settings cannot be saved